### PR TITLE
Add function to convert Celsius to Fahrenheit

### DIFF
--- a/api/end-point.js
+++ b/api/end-point.js
@@ -1,1 +1,6 @@
 console.log("Feature-cxzdkskkcx");
+
+// function to convert Celsius to Fahrenheit
+function celsiusToFahrenheit(celsius) {
+  return (celsius * 9) / 5 + 32;
+}


### PR DESCRIPTION
Added a temperature conversion function: A new function celsiusToFahrenheit(celsius) was implemented that converts temperatures from Celsius to Fahrenheit using the standard conversion formula (celsius * 9) / 5 + 32.

Added documentation: Included a clear comment explaining the purpose of the function.